### PR TITLE
Send latitude and longitude as metrics

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ module.exports = function (app) {
             sourceSrc = u.source.src;
             type = u.source.type;
             var pgn = getPgn(u.source.pgn);
-            if (pgn) {
+            if (pgn && pgn !== undefined) {
               pgnSrc = { pgn: pgn.PGN, id: pgn.Id, description: pgn.Description };
             }
           } else {
@@ -104,6 +104,9 @@ module.exports = function (app) {
 
             if (typeof v.value === 'number') {
               metrics.gauge(data.name, data.value, tags);
+            } else if (v.path == 'navigation.position') {
+              metrics.gauge(data.name + '.latitude', data.value['latitude'], tags);
+              metrics.gauge(data.name + '.longitude', data.value['longitude'], tags);
             } else {
               if (!staticKeys.includes(data.name)) {
                 logger.info(data, { ddsource: 'stream', src: src });
@@ -147,7 +150,11 @@ module.exports = function (app) {
   }
 
   const getPgn = function (pgn) {
-    return organizedPGNs[pgn][0];
+    if (organizedPGNs[pgn] === undefined) {
+      app.debug('ignoring undefined pgn: ' + pgn);
+    } else {
+      return organizedPGNs[pgn][0];
+    }
   };
 
   plugin.stop = function () {


### PR DESCRIPTION
👋 In the current implementation `latitude` and `longitude` are only exposed via log messages, while these can be extracted to metrics, it seems more appropriate to have them as gauges directly.

This PR also cleans up stack traces that report for many unknown PGNs that are found.  This could be an artifact of running signalk with the option `--sample-n2k-data`, however, since it hasn't yet be tested against a live system.